### PR TITLE
关于使用office365邮箱的smtp无法正常发送的修改建议

### DIFF
--- a/options.php
+++ b/options.php
@@ -522,7 +522,7 @@ function optionsframework_options(){
         'type'=>'checkbox');
     $options[] = array(
         'name'=>'SMTPSecure设置',
-        'desc'=>'若启用SMTPAuth服务则填写ssl，若不启用则留空',
+        'desc'=>'若启用SMTPAuth服务则填写ssl，若不启用则留空，office365的邮箱如果无法使用请填写STARTTLS试试',
         'id'=>'mail_smtpsecure',
         'std'=>'ssl',
         'type'=>'text');


### PR DESCRIPTION
修改原因：office365 使用的smtp加密方式为STARTTLS，并不是ssl。考虑到其他邮箱用户可能还在使用ssl进行加密，因此没有直接修改默认值。