### PR TITLE
史前的Flash播放器更改为新版播放器

### DIFF
--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -193,9 +193,15 @@ function pptv($atts,$content=null,$code=""){
 }
 add_shortcode('pptv','pptv');
 function bilibili($atts,$content=null,$code=""){
-    $return = '<div class="video-container"><embed height="415" width="544" quality="high" allowfullscreen="true" type="application/x-shockwave-flash" src="https://static.hdslb.com/miniloader.swf" flashvars="aid=';
+    extract(shortcode_atts(array("cid"=>'0'),$atts));
+    extract(shortcode_atts(array("page"=>'0'),$atts));
+    $return = '<div class="video-container"><iframe src="//player.bilibili.com/player.html?aid=';
     $return .= $content;
-    $return .= '&page=1" pluginspage="https://www.adobe.com/shockwave/download/download.cgi?P1_Prod_Version=ShockwaveFlash"></embed></div>';
+    $return .= '&cid=';
+    $return .= $cid;
+    $return .= '&page=';
+    $return .= $page;
+    $return .= '" allowtransparency="true" width="640" height="400" scrolling="no" frameborder="0" ></iframe></div>';
     return $return;
 }
 add_shortcode('bilibili','bilibili');


### PR DESCRIPTION
史前播放器报31x错误，更改为新版播放器可以解决，多了一个page参数方便插入分P视频，食用方法
https://www.bilibili.com/widget/getPageList?aid=10582565
[bilibili cid="18518844" page="1"]10582565[/bilibili]