### PR TITLE
[优化]更新了Bilibili短代码以及增加“黑幕”样式

### DIFF
--- a/inc/buttons/more.js
+++ b/inc/buttons/more.js
@@ -320,7 +320,7 @@
                 title : '哔哩哔哩',
                 image : url+'/images/bilibili.png',
                 onclick : function() {
-                     ed.selection.setContent('[bilibili cid="" page="1"]' + ed.selection.getContent() + '[/bilibili]');
+                     ed.selection.setContent('[bilibili danmaku="1" page="1"]' + ed.selection.getContent() + '[/bilibili]');
                 }
             });
         },

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -186,14 +186,14 @@ function youtube($atts,$content=null,$code=""){
 }
 add_shortcode('youtube','youtube');
 function bilibili($atts,$content=null,$code=""){
-    extract(shortcode_atts(array("cid"=>'0'),$atts));
+    extract(shortcode_atts(array("danmaku"=>'1'),$atts));
     extract(shortcode_atts(array("page"=>'1'),$atts));
-    $return = '<div class="video-container"><iframe src="https://player.bilibili.com/player.html?aid=';
+    $return = '<div class="video-container"><iframe src="https://player.bilibili.com/player.html?bvid=';
     $return .= $content;
-    $return .= '&cid=';
-    $return .= $cid;
     $return .= '&page=';
     $return .= $page;
+    $return .= '&high_quality=1&danmaku=';
+    $return .= $danmaku;
     $return .= '" allowtransparency="true" width="100%" height="498" scrolling="no" frameborder="0" ></iframe></div>';
     return $return;
 }

--- a/static/css/kratos.min.css
+++ b/static/css/kratos.min.css
@@ -878,3 +878,44 @@ body{background:#fff!important}
 #kratos-header,.kratos-start,#kratos-widget-area,.comments-area .avatar,#respond,.cd-tool{display:none}
 .comments-area .comment-awaiting-moderation,.comments-area .comment-meta,.comments-area .fn{margin-left:0}
 }
+/* 
+ * 请尊重萌娘百科版权，以下代码除非注明均是管理员手敲出来的！！！复制需要注明源自萌娘百科，并且附上URL地址http://zh.moegirl.org/MediaWiki:Common.css
+ * 版权协定：知识共享 署名-非商业性使用-相同方式共享 3.0
+ * 复制之后请把图片换成自己网站上URL地址！
+ */
+span.heimu a.external,
+span.heimu a.external:visited,
+span.heimu a.extiw,
+span.heimu a.extiw:visited {
+    color: #252525;
+}
+.heimu,
+.heimu a,
+a .heimu,
+.heimu a.new {
+    background-color: #252525;
+    color: #252525;
+    text-shadow: none;
+}
+body:not(.heimu_toggle_on) .heimu:hover,
+body:not(.heimu_toggle_on) .heimu:active,
+body:not(.heimu_toggle_on) .heimu.off {
+    transition: color .13s linear;
+    color: white;
+}
+body:not(.heimu_toggle_on) .heimu:hover a,
+body:not(.heimu_toggle_on) a:hover .heimu,
+body:not(.heimu_toggle_on) .heimu.off a,
+body:not(.heimu_toggle_on) a:hover .heimu.off {
+    transition: color .13s linear;
+    color: lightblue;
+}
+body:not(.heimu_toggle_on) .heimu.off .new,
+body:not(.heimu_toggle_on) .heimu.off .new:hover,
+body:not(.heimu_toggle_on) .new:hover .heimu.off,
+body:not(.heimu_toggle_on) .heimu.off .new,
+body:not(.heimu_toggle_on) .heimu.off .new:hover,
+body:not(.heimu_toggle_on) .new:hover .heimu.off {
+    transition: color .13s linear;
+    color: #BA0000;
+}


### PR DESCRIPTION
### 做了两处修改/更新
#### 一、bilibili短代码
B站还是很受年轻人喜欢的emmm最近的博客需要用到插入Bilibili视频，才发现这个问题：
现有的短代码需要获取cid参数，较为不方便；而且视频插入之后是360P，清晰度较低；同时现在B站已经全面将AV号升级为BV号。所以现有的短代码较为落后。经过抓包分析后，提出解决方案：
视频的URL更新为：https://player.bilibili.com/player.html?bvid=
例如：https://player.bilibili.com/player.html?bvid=BV1J64y1u7DV （BV这两个字母可带可不带，**均兼容**），**不需要cid参数，我已直接删去。**
同时，视频清晰度经分析后发现high_quality参数，其值为1时为最高清；为0时是最低视频质量(默认)。考虑到短代码的参数不宜过多，同时博客插入的视频对访客来说是希望更清晰的，所以这个值我没有写成参数而是**固定为了1**。
此外，我**新增了danmaku参数**。这个参数有0和1两个取值，默认为1。这个参数表示是否开启弹幕。1为开启(默认)，0为关闭。
page参数保持不变。
综上所述，最终呈现的URL示例如下：https://player.bilibili.com/player.html?bvid=BV1J64y1u7DV&page=1&high_quality=1&danmaku=1

**短代码使用（示例）**：`[bilibili danmaku="1" page="1"]BV1J64y1u7DV[/bilibili]`

#### 二、新增“黑幕样式”
如果经常玩“萌娘百科”的话，一定对黑幕样式不陌生。就是：写的字全部是黑色的方块看不见，只有当鼠标浮在上面时，字才会变白显现，同时出现“你知道的太多了”这个字样（其实就是个title）。
官方示例链接：[黑幕模板](https://zh.moegirl.org/zh-hans/Template:%E9%BB%91%E5%B9%95)
我查阅了官方的开源代码，将其css直接添加到了主题的css的末尾。使得该种写法受到了支持。
**使用方法（示例）**：`<span class="heimu" title="你知道的太多了">嘿嘿嘿</span>`

此外，如果有出现网易云音乐链接和bilibili短视频不显示的情况（~~对我踩坑了~~），可以考虑`在Chrome设置菜单中： 高级 > 隐私设置和安全性 > 内容设置 > Cookie > 阻止第三方Cookie
`，将这项关闭。因为这两项都需要这个。